### PR TITLE
stm32_temp driver extended by an option to set the ADC reference volt…

### DIFF
--- a/include/zephyr/drivers/sensor/stm32_temp.h
+++ b/include/zephyr/drivers/sensor/stm32_temp.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Tools for Humanity GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_attribute_stm32_temp {
+	SENSOR_ATTR_VREF_MV = SENSOR_ATTR_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_ */


### PR DESCRIPTION
…age by the attribute SENSOR_ATTR_REFERENCE_VOLTAGE_MV. If this attribute is not set then the reference voltage is taken from the adc node in the device tree.