### PR TITLE
stm32 temp ref voltage attribute

### DIFF
--- a/include/zephyr/drivers/sensor/stm32_temp.h
+++ b/include/zephyr/drivers/sensor/stm32_temp.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Tools for Humanity GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_attribute_stm32_temp {
+	SENSOR_ATTR_VREF_MV = SENSOR_ATTR_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_ */


### PR DESCRIPTION
Added a new attribute SENSOR_ATTR_VREF_MV for setting the ADC reference voltage after boot time. This was needed for using the driver on a hardware where the reference voltage is not fixed.

If the new attribute is not set then the ADC reference voltage is used from the ADC node in the device tree as in older versions of this driver.