### PR TITLE
Bugfix: set ADC_CFGR_DMAEN with STM32G474

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -707,7 +707,7 @@ static void dma_callback(const struct device *dev, void *user_data,
 {
 	/* user_data directly holds the adc device */
 	struct adc_stm32_data *data = user_data;
-	const struct adc_stm32_cfg *config = dev->config;
+	const struct adc_stm32_cfg *config = data->dev->config;
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 
 	LOG_DBG("dma callback");

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -229,6 +229,8 @@ static int adc_stm32_dma_start(const struct device *dev,
 	}
 #elif defined(ADC_VER_V5_X)
 	LL_ADC_REG_SetDataTransferMode(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
+#else
+	LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
 #endif
 
 	data->dma_error = 0;


### PR DESCRIPTION
Bugfix: ADC_CFGR_DMAEN bit was not set when using this driver with an STM32G474.

Bugfix: use correct device in dma callback from this commit: https://github.com/zephyrproject-rtos/zephyr/commit/8f73a479d1c345a76e3d47496a7ae430cb8bcbeb