### PR TITLE
i2c: stm32: init priority per device instance

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -1,6 +1,6 @@
 name: Coding Guidelines
 
-on: pull_request
+on: [pull_request, workflow_call]
 
 jobs:
   compliance_job:

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -707,7 +707,7 @@ static void dma_callback(const struct device *dev, void *user_data,
 {
 	/* user_data directly holds the adc device */
 	struct adc_stm32_data *data = user_data;
-	const struct adc_stm32_cfg *config = dev->config;
+	const struct adc_stm32_cfg *config = data->dev->config;
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 
 	LOG_DBG("dma callback");

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -229,6 +229,8 @@ static int adc_stm32_dma_start(const struct device *dev,
 	}
 #elif defined(ADC_VER_V5_X)
 	LL_ADC_REG_SetDataTransferMode(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
+#else
+	LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
 #endif
 
 	data->dma_error = 0;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -122,8 +122,14 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_BLOCK);
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
-#ifdef CONFIG_DMAMUX_STM32
-		stream->busy = false;
+#if CONFIG_DMAMUX_STM32
+		/*
+		 * Clear the busy flag only for transmissions (MEMORY_TO_PERIPHERAL)
+		 * because circular buffer never stops receiving as long as peripheral is enabled
+		 */
+		if (!stream->circular || stream->direction == MEMORY_TO_PERIPHERAL) {
+			stream->busy = false;
+		}
 #endif
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -361,6 +367,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	stream->user_data       = config->user_data;
 	stream->src_size	= config->source_data_size;
 	stream->dst_size	= config->dest_data_size;
+	stream->circular	= config->cyclic || config->head_block->source_reload_en;
 
 	/* Check dest or source memory address, warn if 0 */
 	if (config->head_block->source_address == 0) {
@@ -432,7 +439,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	LOG_DBG("Channel (%d) peripheral inc (%x).",
 				id, DMA_InitStruct.PeriphOrM2MSrcIncMode);
 
-	if (config->head_block->source_reload_en) {
+	if (stream->circular) {
 		DMA_InitStruct.Mode = LL_DMA_MODE_CIRCULAR;
 	} else {
 		DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
@@ -494,7 +501,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
 
 	/* Enable Half-Transfer irq if circular mode is enabled */
-	if (config->head_block->source_reload_en) {
+	if (stream->circular) {
 		LL_DMA_EnableIT_HT(dma, dma_stm32_id_to_stream(id));
 	}
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -26,7 +26,8 @@ struct dma_stm32_stream {
 	uint32_t src_size;
 	uint32_t dst_size;
 	void *user_data; /* holds the client data */
-	dma_callback_t dma_callback;
+	dma_callback_t dma_callback; /* with status = 1 for half-complete transfer */
+	bool circular; /* set from dma_config (cyclic) or dma_block_config (source_reload_en) */
 };
 
 struct dma_stm32_data {

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -543,6 +543,22 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)	\
 #define USE_TIMINGS(index)
 #endif /* V2 */
 
+/* allow redefinition of init priority, per instance,
+ * at least for the 4 first instances
+ */
+#ifndef CONFIG_I2C_INIT_PRIO_INST_0
+#define CONFIG_I2C_INIT_PRIO_INST_0 CONFIG_I2C_INIT_PRIORITY
+#endif
+#ifndef CONFIG_I2C_INIT_PRIO_INST_1
+#define CONFIG_I2C_INIT_PRIO_INST_1 CONFIG_I2C_INIT_PRIORITY
+#endif
+#ifndef CONFIG_I2C_INIT_PRIO_INST_2
+#define CONFIG_I2C_INIT_PRIO_INST_2 CONFIG_I2C_INIT_PRIORITY
+#endif
+#ifndef CONFIG_I2C_INIT_PRIO_INST_3
+#define CONFIG_I2C_INIT_PRIO_INST_3 CONFIG_I2C_INIT_PRIORITY
+#endif
+
 #define STM32_I2C_INIT(index)						\
 STM32_I2C_IRQ_HANDLER_DECL(index);					\
 									\
@@ -573,7 +589,8 @@ I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,			\
 			 PM_DEVICE_DT_INST_GET(index),			\
 			 &i2c_stm32_dev_data_##index,			\
 			 &i2c_stm32_cfg_##index,			\
-			 POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,		\
+			 POST_KERNEL,                                   \
+			 _CONCAT(CONFIG_I2C_INIT_PRIO_INST_, index),	\
 			 &api_funcs);					\
 									\
 STM32_I2C_IRQ_HANDLER(index)

--- a/drivers/sensor/vl53l1x/Kconfig
+++ b/drivers/sensor/vl53l1x/Kconfig
@@ -29,4 +29,19 @@ config VL53L1X_XSHUT
 	  Enable to use the xshut pin on the VL53L1X. If not, the pin should be
 	  connected to VDD.
 
+config VL53L1X_PROXIMITY_THRESHOLD
+    int "Proximity threshold in millimeters"
+    default 100
+    help
+        Threshold used for proximity detection when sensor is used with SENSOR_CHAN_PROX.
+
+config VL53L1X_SIGNAL_SPAD_RATIO_THRESHOLD
+	int "Signal SPAD ratio threshold"
+	default 300
+	help
+	  The signal to SPAD-count ratio is used for proximity detection when sensor is used with SENSOR_CHAN_PROX.
+	  It helps remove false positives when the sensor is used in a dark environment and spits out phantom readings.
+	  The ratio is calculated as follows:
+	  	ratio = (Signal rate / SPAD count) * 1000
+
 endif # VL53L1X

--- a/drivers/sensor/vl53l1x/vl53l1.c
+++ b/drivers/sensor/vl53l1x/vl53l1.c
@@ -65,59 +65,56 @@ static VL53L1_Error vl53l1x_read_sensor(struct vl53l1x_data *drv_data)
 	return VL53L1_ERROR_NONE;
 }
 
+#ifdef CONFIG_VL53L1X_INTERRUPT_MODE
 static void vl53l1x_worker(struct k_work *work)
 {
-	if (IS_ENABLED(CONFIG_VL53L1X_INTERRUPT_MODE)) {
-		struct vl53l1x_data *drv_data = CONTAINER_OF(work, struct vl53l1x_data, work);
+	struct vl53l1x_data *drv_data = CONTAINER_OF(work, struct vl53l1x_data, work);
 
-		vl53l1x_read_sensor(drv_data);
-	}
+	vl53l1x_read_sensor(drv_data);
 }
 
 static void vl53l1x_gpio_callback(const struct device *dev,
 		struct gpio_callback *cb, uint32_t pins)
 {
-	if (IS_ENABLED(CONFIG_VL53L1X_INTERRUPT_MODE)) {
-		struct vl53l1x_data *drv_data = CONTAINER_OF(cb, struct vl53l1x_data, gpio_cb);
+	struct vl53l1x_data *drv_data = CONTAINER_OF(cb, struct vl53l1x_data, gpio_cb);
 
-		k_work_submit(&drv_data->work);
-	}
+	k_work_submit(&drv_data->work);
 }
 
 static int vl53l1x_init_interrupt(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_VL53L1X_INTERRUPT_MODE)) {
-		struct vl53l1x_data *drv_data = dev->data;
-		const struct vl53l1x_config *config = dev->config;
-		int ret;
+	struct vl53l1x_data *drv_data = dev->data;
+	const struct vl53l1x_config *config = dev->config;
+	int ret;
 
-		drv_data->dev = dev;
+	drv_data->dev = dev;
 
-		if (!device_is_ready(config->gpio1.port)) {
-			LOG_ERR("%s: device %s is not ready", dev->name, config->gpio1.port->name);
-			return -ENODEV;
-		}
-
-		ret = gpio_pin_configure_dt(&config->gpio1, GPIO_INPUT | GPIO_PULL_UP);
-		if (ret < 0) {
-			LOG_ERR("[%s] Unable to configure GPIO interrupt", dev->name);
-			return -EIO;
-		}
-
-		gpio_init_callback(&drv_data->gpio_cb,
-						vl53l1x_gpio_callback,
-						BIT(config->gpio1.pin));
-
-		ret = gpio_add_callback(config->gpio1.port, &drv_data->gpio_cb);
-		if (ret < 0) {
-			LOG_ERR("Failed to set gpio callback!");
-			return -EIO;
-		}
-
-		drv_data->work.handler = vl53l1x_worker;
+	if (!device_is_ready(config->gpio1.port)) {
+		LOG_ERR("%s: device %s is not ready", dev->name, config->gpio1.port->name);
+		return -ENODEV;
 	}
+
+	ret = gpio_pin_configure_dt(&config->gpio1, GPIO_INPUT | GPIO_PULL_UP);
+	if (ret < 0) {
+		LOG_ERR("[%s] Unable to configure GPIO interrupt", dev->name);
+		return -EIO;
+	}
+
+	gpio_init_callback(&drv_data->gpio_cb,
+					vl53l1x_gpio_callback,
+					BIT(config->gpio1.pin));
+
+	ret = gpio_add_callback(config->gpio1.port, &drv_data->gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Failed to set gpio callback!");
+		return -EIO;
+	}
+
+	drv_data->work.handler = vl53l1x_worker;
+
 	return 0;
 }
+#endif
 
 static int vl53l1x_initialize(const struct device *dev)
 {
@@ -304,7 +301,6 @@ static int vl53l1x_sample_fetch(const struct device *dev,
 		enum sensor_channel chan)
 {
 	struct vl53l1x_data *drv_data = dev->data;
-	const struct vl53l1x_config *config = dev->config;
 	VL53L1_Error ret;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_DISTANCE);
@@ -316,13 +312,15 @@ static int vl53l1x_sample_fetch(const struct device *dev,
 		return -EBUSY;
 	}
 
-	if (IS_ENABLED(CONFIG_VL53L1X_INTERRUPT_MODE)) {
-		ret = gpio_pin_interrupt_configure_dt(&config->gpio1, GPIO_INT_EDGE_TO_INACTIVE);
-		if (ret < 0) {
-			LOG_ERR("[%s] Unable to config interrupt", dev->name);
-			return -EIO;
-		}
+#ifdef CONFIG_VL53L1X_INTERRUPT_MODE
+	const struct vl53l1x_config *config = dev->config;
+
+	ret = gpio_pin_interrupt_configure_dt(&config->gpio1, GPIO_INT_EDGE_TO_INACTIVE);
+	if (ret < 0) {
+		LOG_ERR("[%s] Unable to config interrupt", dev->name);
+		return -EIO;
 	}
+#endif
 
 	ret = VL53L1_StartMeasurement(&drv_data->vl53l1x);
 	if (ret != VL53L1_ERROR_NONE) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -84,6 +84,12 @@ uint32_t lpuartdiv_calc(const uint64_t clock_rate, const uint32_t baud_rate)
 #endif /* USART_PRESC_PRESCALER */
 #endif /* HAS_LPUART_1 */
 
+#ifdef CONFIG_UART_ASYNC_API
+#define ASYNC_UART_STATUS_TIMEOUT 3
+BUILD_ASSERT(ASYNC_UART_STATUS_TIMEOUT != DMA_STATUS_COMPLETE, "ASYNC_UART_STATUS_TIMEOUT must be different from DMA_STATUS_COMPLETE");
+BUILD_ASSERT(ASYNC_UART_STATUS_TIMEOUT != DMA_STATUS_BLOCK, "ASYNC_UART_STATUS_TIMEOUT must be different from DMA_STATUS_BLOCK");
+#endif
+
 #ifdef CONFIG_PM
 static void uart_stm32_pm_policy_state_lock_get(const struct device *dev)
 {
@@ -556,7 +562,7 @@ static void uart_stm32_poll_out(const struct device *dev,
 #endif
 	unsigned int key;
 
-	/* Wait for TXE flag to be raised
+	/* Wait for TXE flag to be raisedf
 	 * When TXE flag is raised, we lock interrupts to prevent interrupts (notably that of usart)
 	 * or thread switch. Then, we can safely send our character. The character sent will be
 	 * interlaced with the characters potentially send with interrupt transmission API
@@ -967,20 +973,38 @@ static inline void async_timer_start(struct k_work_delayable *work,
 	}
 }
 
-static void uart_stm32_dma_rx_flush(const struct device *dev)
+static void uart_stm32_dma_rx_flush(const struct device *dev, int status)
 {
 	struct dma_status stat;
 	struct uart_stm32_data *data = dev->data;
 
-	if (dma_get_status(data->dma_rx.dma_dev,
-				data->dma_rx.dma_channel, &stat) == 0) {
-		size_t rx_rcv_len = data->dma_rx.buffer_length -
-					stat.pending_length;
-		if (rx_rcv_len > data->dma_rx.offset) {
-			data->dma_rx.counter = rx_rcv_len;
+	size_t rx_rcv_len = 0;
 
-			async_evt_rx_rdy(data);
+	/* status informs about the context and allows us to use the DMA buffer size
+	 * instead of polling the current status which might have changed since interrupt
+	 * fired
+	 */
+	switch (status) {
+	case DMA_STATUS_COMPLETE:
+		/* fully complete */
+		rx_rcv_len = data->dma_rx.buffer_length;
+		break;
+	case DMA_STATUS_BLOCK:
+		/* half complete */
+		rx_rcv_len = data->dma_rx.buffer_length / 2;
+		break;
+	default: /* likely ASYNC_UART_STATUS_TIMEOUT */
+		if (dma_get_status(data->dma_rx.dma_dev,
+				   data->dma_rx.dma_channel, &stat) == 0) {
+			rx_rcv_len = data->dma_rx.buffer_length -
+				     stat.pending_length;
 		}
+	}
+
+	if (rx_rcv_len > data->dma_rx.offset) {
+		data->dma_rx.counter = rx_rcv_len;
+
+		async_evt_rx_rdy(data);
 	}
 }
 
@@ -1031,7 +1055,7 @@ static void uart_stm32_isr(const struct device *dev)
 		LOG_DBG("idle interrupt occurred");
 
 		if (data->dma_rx.timeout == 0) {
-			uart_stm32_dma_rx_flush(dev);
+			uart_stm32_dma_rx_flush(dev, ASYNC_UART_STATUS_TIMEOUT);
 		} else {
 			/* Start the RX timer not null */
 			async_timer_start(&data->dma_rx.timeout_work,
@@ -1135,7 +1159,7 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 
 	LL_USART_DisableIT_IDLE(config->usart);
 
-	uart_stm32_dma_rx_flush(dev);
+	uart_stm32_dma_rx_flush(dev, ASYNC_UART_STATUS_TIMEOUT);
 
 	async_evt_rx_buf_release(data);
 
@@ -1234,12 +1258,9 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 
 	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
 
-	/* true since this functions occurs when buffer if full */
-	data->dma_rx.counter = data->dma_rx.buffer_length;
+	uart_stm32_dma_rx_flush(data->uart_dev, status);
 
-	async_evt_rx_rdy(data);
-
-	if (data->rx_next_buffer != NULL) {
+	if (data->rx_next_buffer != NULL && status == DMA_STATUS_COMPLETE) {
 		async_evt_rx_buf_release(data);
 
 		/* replace the buffer when the current
@@ -1247,14 +1268,10 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 		 * one.
 		 */
 		uart_stm32_dma_replace_buffer(uart_dev);
-	} else {
-		/* Buffer full without valid next buffer,
-		 * an UART_RX_DISABLED event must be generated,
-		 * but uart_stm32_async_rx_disable() cannot be
-		 * called in ISR context. So force the RX timeout
-		 * to minimum value and let the RX timeout to do the job.
-		 */
-		k_work_reschedule(&data->dma_rx.timeout_work, K_TICKS(1));
+	} else if (status == DMA_STATUS_COMPLETE) {
+		/* full so reset offset and counter for next read */
+		data->dma_rx.offset = 0;
+		data->dma_rx.counter = 0;
 	}
 }
 
@@ -1369,7 +1386,7 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 
 	LL_USART_EnableIT_ERROR(config->usart);
 
-	/* Request next buffer */
+	/* Request next buffer in case user wants to use different circular buffers */
 	async_evt_rx_buf_request(data);
 
 	LOG_DBG("async rx enabled");
@@ -1416,7 +1433,7 @@ static void uart_stm32_async_rx_timeout(struct k_work *work)
 	if (data->dma_rx.counter == data->dma_rx.buffer_length) {
 		uart_stm32_async_rx_disable(dev);
 	} else {
-		uart_stm32_dma_rx_flush(dev);
+		uart_stm32_dma_rx_flush(dev, ASYNC_UART_STATUS_TIMEOUT);
 	}
 }
 
@@ -1503,7 +1520,7 @@ static int uart_stm32_async_init(const struct device *dev)
 		data->dma_rx.blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 	}
 
-	/* RX disable circular buffer */
+	/* RX disable circular buffer by default */
 	data->dma_rx.blk_cfg.source_reload_en  = 0;
 	data->dma_rx.blk_cfg.dest_reload_en = 0;
 	data->dma_rx.blk_cfg.fifo_mode_control = data->dma_rx.fifo_threshold;
@@ -1732,8 +1749,14 @@ static int uart_stm32_init(const struct device *dev)
 
 #ifdef USART_ISR_REACK
 	/* Wait until REACK flag is set */
-	while (!(LL_USART_IsActiveFlag_REACK(config->usart))) {
+#ifdef CONFIG_PM
+	if (config->wakeup_source) {
+#endif
+		while (LL_USART_IsActiveFlag_REACK(config->usart) == 0) {
+		}
+#ifdef CONFIG_PM
 	}
+#endif
 #endif /* !USART_ISR_REACK */
 
 #if defined(CONFIG_PM) || \
@@ -1778,9 +1801,16 @@ static void uart_stm32_suspend_setup(const struct device *dev)
 	}
 #ifdef USART_ISR_REACK
 	/* Make sure that USART is ready for reception */
-	while (LL_USART_IsActiveFlag_REACK(config->usart) == 0) {
+#ifdef CONFIG_PM
+	if (config->wakeup_source) {
+#endif
+		while (LL_USART_IsActiveFlag_REACK(config->usart) == 0) {
+		}
+#ifdef CONFIG_PM
 	}
 #endif
+#endif /* !USART_ISR_REACK */
+
 	/* Clear OVERRUN flag */
 	LL_USART_ClearFlag_ORE(config->usart);
 }
@@ -1849,7 +1879,9 @@ static int uart_stm32_pm_action(const struct device *dev,
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),                            \
+		.cyclic = STM32_DMA_CONFIG_CYCLIC(	\
+			STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(\

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -16,6 +16,9 @@ description: |
     or a value beweeen <dma-generators>+1  ..  <dma-generators>+<dma-requests>
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
+        -bit 5 : Cyclic mode
+               0x0: normal mode
+               0x1: circular mode
         -bit 6-7 : Direction  (see dma.h)
                0x0: MEM to MEM
                0x1: MEM to PERIPH

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -211,7 +211,7 @@ struct dma_config {
 	uint32_t  source_chaining_en :   1;
 	uint32_t  dest_chaining_en :     1;
 	uint32_t  linked_channel   :     7;
-	uint32_t  cyclic :				 1;
+	uint32_t  cyclic :		 1;
 	uint32_t  reserved :             3;
 	uint32_t  source_data_size :    16;
 	uint32_t  dest_data_size :      16;

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -52,6 +52,8 @@
 		DT_INST_DMAS_CELL_BY_NAME(id, dir, channel_config)
 
 /* macros for channel-config */
+/* circular mode defined on bit 5 as true/false */
+#define STM32_DMA_CONFIG_CYCLIC(config)			((config >> 5) & 0x1)
 /* direction defined on bits 6-7 */
 /* 0 -> MEM_TO_MEM, 1 -> MEM_TO_PERIPH, 2 -> PERIPH_TO_MEM */
 #define STM32_DMA_CONFIG_DIRECTION(config)		((config >> 6) & 0x3)

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -484,6 +484,11 @@ static inline int z_impl_flash_ex_op(const struct device *dev, uint16_t code,
 
 	return api->ex_op(dev, code, in, out);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(code);
+	ARG_UNUSED(in);
+	ARG_UNUSED(out);
+
 	return -ENOSYS;
 #endif /* CONFIG_FLASH_EX_OP_ENABLED */
 }

--- a/include/zephyr/drivers/sensor/stm32_temp.h
+++ b/include/zephyr/drivers/sensor/stm32_temp.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Tools for Humanity GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_attribute_stm32_temp {
+	SENSOR_ATTR_VREF_MV = SENSOR_ATTR_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_STM32_TEMP_H_ */

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -652,12 +652,16 @@ static inline bool pm_device_on_power_domain(const struct device *dev)
 static inline int pm_device_power_domain_add(const struct device *dev,
 					     const struct device *domain)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(domain);
 	return -ENOSYS;
 }
 
 static inline int pm_device_power_domain_remove(const struct device *dev,
 						const struct device *domain)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(domain);
 	return -ENOSYS;
 }
 

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1177,6 +1177,8 @@ static inline void rtio_cqe_submit(struct rtio *r, int result, void *userdata, u
 static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32_t min_buf_len,
 				  uint32_t max_buf_len, uint8_t **buf, uint32_t *buf_len)
 {
+	ARG_UNUSED(max_buf_len);
+
 	struct rtio_sqe *sqe = (struct rtio_sqe *)&iodev_sqe->sqe;
 
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
@@ -1230,6 +1232,10 @@ __syscall void rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len
 
 static inline void z_impl_rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len)
 {
+	ARG_UNUSED(r);
+	ARG_UNUSED(buff);
+	ARG_UNUSED(buff_len);
+
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
 	if (r == NULL || buff == NULL || r->block_pool == NULL || buff_len == 0) {
 		return;


### PR DESCRIPTION
allow redefinition of i2c device initialization priority per instance so that one bus can be initialized for a specific purpose before another